### PR TITLE
Optmize events

### DIFF
--- a/Assets/Scripts/Classes/PieceComponent/CommandManager.cs
+++ b/Assets/Scripts/Classes/PieceComponent/CommandManager.cs
@@ -77,9 +77,12 @@ namespace Assets.Scripts.Classes.PieceComponent
         /// </summary>
         private void DoWork()
         {
-            // Execute the pre-configured command (typically a ConcreteMoveCommand)
-            _invoker.ExecuteCommand(_command);
-            Debug.Log($"{nameof(DoWork)} executed");
+            {
+                if (PieceSelectionComponent.SelectedPiece == (PieceSelectionComponent)_pieceSelectionComponent)
+                    // Execute the pre-configured command (typically a ConcreteMoveCommand)
+                    _invoker.ExecuteCommand(_command);
+                Debug.Log($"{nameof(DoWork)} executed");
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Classes/PieceComponent/CommandManager.cs
+++ b/Assets/Scripts/Classes/PieceComponent/CommandManager.cs
@@ -36,7 +36,6 @@ namespace Assets.Scripts.Classes.PieceComponent
         /// The execution wrapper that triggers the command lifecycle.
         /// </summary>
         private CommandInvoker _invoker;
-
         #endregion
 
         #region Lifecycle Methods
@@ -46,6 +45,7 @@ namespace Assets.Scripts.Classes.PieceComponent
         /// </summary>
         private void Start()
         {
+          
             // Resolve interface-based dependencies from the current GameObject
             _pieceSelectionComponent = GetComponent<ISelectable>();
             _move = GetComponent<IMove>();
@@ -78,10 +78,14 @@ namespace Assets.Scripts.Classes.PieceComponent
         private void DoWork()
         {
             {
-                if (PieceSelectionComponent.SelectedPiece == (PieceSelectionComponent)_pieceSelectionComponent)
+                if (ReferenceEquals(PieceSelectionComponent.SelectedPiece, _pieceSelectionComponent))
+                {
                     // Execute the pre-configured command (typically a ConcreteMoveCommand)
                     _invoker.ExecuteCommand(_command);
-                Debug.Log($"{nameof(DoWork)} executed");
+
+                    Debug.Log($"{nameof(DoWork)}");
+                }
+          
             }
         }
 

--- a/Assets/Scripts/Classes/PieceComponent/PieceSelectionComponent.cs
+++ b/Assets/Scripts/Classes/PieceComponent/PieceSelectionComponent.cs
@@ -25,7 +25,7 @@ namespace Assets.Scripts.Classes.PieceComponent
         /// Global reference to the currently active selection. 
         /// Ensures mutual exclusivity of piece selection across the board.
         /// </summary>
-        private static PieceSelectionComponent _selectedPiece;
+        public static PieceSelectionComponent SelectedPiece;
 
         /// <inheritdoc cref="ISelectable.Status"/>
         public SelectionStatus Status { get; set; }
@@ -58,19 +58,19 @@ namespace Assets.Scripts.Classes.PieceComponent
             //  if (!CanMove) return;
             CurrentPosition = Board.BoardInstance.tilemap.WorldToCell(transform.position);
             // Enforce Single Selection Policy
-            if (_selectedPiece is not null && _selectedPiece != this)
+            if (SelectedPiece is not null && SelectedPiece != this)
             {
-                _selectedPiece.OnDeselect();
+                SelectedPiece.OnDeselect();
             }
 
-            _selectedPiece = this;
+            SelectedPiece = this;
             Status = SelectionStatus.Selected;
         }
 
         /// <inheritdoc />
         public void OnDeselect()
         {
-            if (_selectedPiece == this) _selectedPiece = null;
+            if (SelectedPiece == this) SelectedPiece = null;
             Status = SelectionStatus.UnSelected;
         }
 


### PR DESCRIPTION
I noticed that , the PieceSelectionComponent.OnPieceSelectedEvent event is being executed for all 32 pieces when only 1 pieces is clicked , so , I used a Reference comparaison between CommandManager._pieceSelectionComponent and PieceSelectionComponent.SelectedPiece via the System.Object.ReferenceEquals(object objA, object objB) to fire DoWork if this method returns true

       private void DoWork()
        {
            {
                if (ReferenceEquals(PieceSelectionComponent.SelectedPiece, _pieceSelectionComponent))
                {
                    // Execute the pre-configured command (typically a ConcreteMoveCommand)
                    _invoker.ExecuteCommand(_command);

                    Debug.Log($"{nameof(DoWork)}");
                }
          
            }
        }